### PR TITLE
Update gatsby-node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,42 @@ module.exports = {
 
 That's it, when you build your app you will have gzipped versions of your files.
 
+Or you can use it with additional options;
+
+```javascript
+
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-plugin-compression-v2`,
+      options: {
+        asset: '[path].gz[query]',
+        algorithm: 'gzip'
+      },
+    }
+  ],
+}
+
+```
+
+Keep in mind this option setting is also the default options when you don't specify anything. See full options for the webpack addon;
+
+
+|Name|Type|Default|Description|
+|:--:|:--:|:-----:|:----------|
+|**[`test`](#test)**|`{RegExp\|Array<RegExp>}`|`.`|All assets matching this `{RegExp\|Array<RegExp>}` are processed|
+|**[`include`](#include)**|`{RegExp\|Array<RegExp>}`|`undefined`|Files to `include`|
+|**[`exclude`](#exclude)**|`{RegExp\|Array<RegExp>}`|`undefined`|Files to `exclude`|
+|**[`cache`](#cache)**|`{Boolean\|String}`|`false`|Enable file caching|
+|**[`asset`](#asset)**|`{String}`|`[path].gz[query]`|The target asset name. `[file]` is replaced with the original asset. `[path]` is replaced with the path of the original asset and `[query]` with the query|
+|**[`filename`](#filename)**|`{Function}`|`false`|A `{Function}` `(asset) => asset` which receives the asset name (after processing `asset` option) and returns the new asset name|
+|**[`algorithm`](#algorithm)**|`{String\|Function}`|`gzip`|Can be `(buffer, cb) => cb(buffer)` or if a `{String}` is used the algorithm is taken from `zlib`|
+|**[`threshold`](#threshold)**|`{Number}`|`0`|Only assets bigger than this size are processed. In bytes.|
+|**[`minRatio`](#minratio)**|`{Number}`|`0.8`|Only assets that compress better than this ratio are processed|
+|**[`deleteOriginalAssets`](#deleteoriginalassets)**|`{Boolean}`|`false`|Whether to delete the original assets or not|
+
+
+
 # Nginx
 
 If your using nginx you can use `gzip_static on;` to serve your gzipped assets, here's a full example.

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,16 +1,20 @@
 const CompressionPlugin = require("compression-webpack-plugin");
 
 exports.onCreateWebpackConfig = ({ stage, actions }, options) => {
+  if(!options){
+    // Default options for ordinary gatsby project.
+    options = {
+      asset: '[path].gz[query]',
+      algorithm: 'gzip'
+    };
+  }
   switch (stage) {
     case `build-html`:
     case `build-javascript`:
     case `build-css`:
       actions.setWebpackConfig({
         plugins: [
-          new CompressionPlugin({
-            asset: '[path].gz[query]',
-            algorithm: 'gzip'
-          })
+          new CompressionPlugin(options)
         ],
       })
   }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,18 +1,17 @@
 const CompressionPlugin = require("compression-webpack-plugin");
 
-exports.onCreateWebpackConfig = ({ config, stage }, options) => {
+exports.onCreateWebpackConfig = ({ stage, actions }, options) => {
   switch (stage) {
     case `build-html`:
     case `build-javascript`:
-    case `build-css`: {
-      config.plugin(`compression`,
-        CompressionPlugin,
-        [{asset: '[path].gz[query]', algorithm: 'gzip'}]
-      );
-      return config
-    }
-    default: {
-      return config
-    }
+    case `build-css`:
+      actions.setWebpackConfig({
+        plugins: [
+          new CompressionPlugin({
+            asset: '[path].gz[query]',
+            algorithm: 'gzip'
+          })
+        ],
+      })
   }
 }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,6 +1,6 @@
 const CompressionPlugin = require("compression-webpack-plugin");
 
-exports.modifyWebpackConfig = ({ config, stage }, options) => {
+exports.onCreateWebpackConfig = ({ config, stage }, options) => {
   switch (stage) {
     case `build-html`:
     case `build-javascript`:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-compression",
-  "version": "0.0.1",
-  "description": "Gatsby plugin for compressing assets.",
+  "version": "0.1.0",
+  "description": "Gatsby plugin for compressing assets. (gzip)",
   "main": "gatsby-node.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -11,7 +11,7 @@
     "plugin",
     "compression"
   ],
-  "author": "Harrison Bowden",
+  "author": "btk",
   "license": "ISC",
   "dependencies": {
     "compression-webpack-plugin": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gatsby-plugin-compression",
+  "name": "gatsby-plugin-compression-v2",
   "version": "0.1.0",
   "description": "Gatsby plugin for compressing assets. (gzip)",
   "main": "gatsby-node.js",


### PR DESCRIPTION
in v2, api name is changed, into `onCreateWebpackConfig`

See: https://github.com/gatsbyjs/gatsby/blob/605759d34f6f0e432e02f866a3e4ec4fef659855/docs/docs/migrating-from-v1-to-v2.md#change-modifywebpackconfig-to-oncreatewebpackconfig